### PR TITLE
Consistent format for URLs (with trailing slash).

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -11,10 +11,10 @@ imports:
 
 sponsors:
     - name: Sift
-      website: http://www.sift.com
+      website: http://www.sift.com/
 
     - name: Microserve
-      website: https://microserve.io
+      website: https://microserve.io/
 
     - name: Halo
-      website: http://wearehalo.co.uk
+      website: http://wearehalo.co.uk/

--- a/app/config/venues.yml
+++ b/app/config/venues.yml
@@ -6,7 +6,7 @@ venues:
 
     proctors:
         name: 'Proctor & Stevenson'
-        website: http://www.proctors.co.uk
+        website: http://www.proctors.co.uk/
 
     the_elephant:
         name: The Elephant


### PR DESCRIPTION
Made sure the venue and sponsor URLs use a consistent format. Added trailing slash to the ones missing it. (with slashes seemed to be slightly more common).
